### PR TITLE
Extending a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Screenshot of podcast-player](https://s3.amazonaws.com/f.cl.ly/items/3Q47193Z0f00142R0O42/1d0pzyOUeVH2-d1m77Vxx9QkL0vexZ5bJNbyEGRCfbY.png)
 
 ```
-<podcast-player src="my.mp3"></podcast-player>
+<a href="my.mp3" is="podcast-player">Listen</a>
 ```
 
 A web component for audio podcasts. It has a few features that make it most suitable for podcasts:
@@ -31,10 +31,10 @@ Include `webcomponents.min.js` and `podcast-player.html` in the `<head>` of your
 <link rel="import" href="podcast-player.html"/>
 ```
 
-Then in the body of your post, invoke the custom component using the `<podcast-player>` element.
+Then in the body of your post, invoke the custom component using an `<a>` element with the `is="podcast-player"` attribute.
 
 ```
-<podcast-player src="my.mp3"></podcast-player>
+<a href="my.mp3" is="podcast-player">Listen</a>
 ```
 
 BINGO-BANGO! Now you should be able to style it with good old fashioned CSS. Make it your own, good buddy.

--- a/demo.html
+++ b/demo.html
@@ -5,6 +5,8 @@
   <link rel="import" href="podcast-player.html"/>
 </head>
 <body>
-  <podcast-player src="https://archive.org/download/MartinLutherKing-IHaveADream/MartinLutherKing-IHaveADream.mp3"></podcast-player>
+  <a href="https://archive.org/download/MartinLutherKing-IHaveADream/MartinLutherKing-IHaveADream.mp3" is="podcast-player">
+    Listen
+  </a>
 </body>
 </html>

--- a/podcast-player.html
+++ b/podcast-player.html
@@ -130,7 +130,7 @@ proto.createdCallback = function() {
   var audio = player.querySelector('audio');
 
   // TODO: There's probably a more "{{templatey}}" way to do this.
-  audio.src = player.getAttribute('src');
+  audio.src = player.getAttribute('href');
 
   // Buttons
   var play = player.querySelector('.button-play');

--- a/podcast-player.html
+++ b/podcast-player.html
@@ -118,7 +118,13 @@ var proto = Object.create(HTMLLinkElement.prototype);
 proto.createdCallback = function() {
   var player = this;
   var clone = document.importNode(tmpl.content, true);
+  player.innerHTML = '';
   player.appendChild(clone);
+
+  // Cancel default link behaviour
+  player.addEventListener('click', function(e){
+    e.preventDefault();
+  })
 
   // HTMLAudioElement
   var audio = player.querySelector('audio');

--- a/podcast-player.html
+++ b/podcast-player.html
@@ -113,7 +113,7 @@
 <script>
 var owner = document._currentScript.ownerDocument;
 var tmpl = owner.querySelector('template');
-var proto = Object.create(HTMLElement.prototype);
+var proto = Object.create(HTMLLinkElement.prototype);
 
 proto.createdCallback = function() {
   var player = this;
@@ -211,5 +211,5 @@ proto.createdCallback = function() {
 
 }
 
-document.registerElement('podcast-player', { prototype: proto });
+document.registerElement('podcast-player', { prototype: proto, extends: 'a' });
 </script>


### PR DESCRIPTION
Hey Dave, I've fiddled around with your podcast-player code so that it extends an A element instead of creating a completely new custom element. My thinking here is that in browsers that don't support web components, people will still have access to the audio file the good ol' fashioned way.

Whaddya think?
